### PR TITLE
Control deny(warnings) with a feature

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@
       name: check
       language: system
       files: '[.]rs$'
-      entry: cargo rustc -- -D warnings
+      entry: cargo check --all-targets --features strict
       pass_filenames: false
 
     - id: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - stable
 
 script:
-  - cargo rustc -- -D warnings
+  - cargo check --all-targets --features strict
   - cargo test
 
 matrix:
@@ -16,7 +16,7 @@ matrix:
       before_script:
         - rustup component add rustfmt-preview
       script:
-        - cargo rustc -- -D warnings
+        - cargo check --all-targets --features strict
         - cargo test
         - cargo fmt -- --check
         - cargo rustdoc -- --deny warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ flatbuffers = "0.4.0"
 nalgebra = "0.16.0"
 winapi = { version = "0.3.5", features = ["synchapi"] }
 winproc = "0.5.1"
+
+[features]
+strict = []

--- a/examples/gravity.rs
+++ b/examples/gravity.rs
@@ -1,5 +1,7 @@
 //! The ball is a neutron star. The cars are planets.
 
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 extern crate flatbuffers;
 extern crate nalgebra as na;
 extern crate rlbot;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,6 +2,8 @@
 //! blindly towards the ball no matter what is happening on the field (just
 //! like Dory from Finding Nemo).
 
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 extern crate nalgebra as na;
 extern crate rlbot;
 

--- a/examples/simple_flatbuffer.rs
+++ b/examples/simple_flatbuffer.rs
@@ -2,6 +2,8 @@
 //! blindly towards the ball no matter what is happening on the field (just
 //! like Dory from Finding Nemo).
 
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 extern crate flatbuffers;
 extern crate nalgebra as na;
 extern crate rlbot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! [`examples/simple_flatbuffer`]: https://github.com/whatisaphone/rlbot-rust/blob/master/examples/simple_flatbuffer.rs
 //! [`examples/gravity`]: https://github.com/whatisaphone/rlbot-rust/blob/master/examples/gravity.rs
 
-#![warn(missing_docs)]
+#![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
 
 extern crate flatbuffers;
 extern crate libloading;

--- a/tests/init_twice.rs
+++ b/tests/init_twice.rs
@@ -1,4 +1,5 @@
 #![cfg(windows)]
+#![cfg_attr(feature = "strict", deny(warnings))]
 
 extern crate rlbot;
 extern crate winapi;

--- a/tests/packeteer_error_when_no_packets.rs
+++ b/tests/packeteer_error_when_no_packets.rs
@@ -1,4 +1,5 @@
 #![cfg(windows)]
+#![cfg_attr(feature = "strict", deny(warnings))]
 
 extern crate rlbot;
 extern crate winapi;

--- a/tests/packeteer_happy.rs
+++ b/tests/packeteer_happy.rs
@@ -1,4 +1,5 @@
 #![cfg(windows)]
+#![cfg_attr(feature = "strict", deny(warnings))]
 
 extern crate rlbot;
 extern crate winapi;


### PR DESCRIPTION
The old way breaks cargo's build caching (and it's a bit hacky to begin
with)