### PR TITLE
Load DLLs from the framework-provided directory

### DIFF
--- a/src/dll.rs
+++ b/src/dll.rs
@@ -1,8 +1,9 @@
-use crate::ffi::*;
+use crate::{ffi::*, utils::maybe_join};
 use libloading::Library;
 use std::{
     error::Error,
     io,
+    path::Path,
     sync::atomic::{AtomicBool, Ordering},
     thread::sleep,
     time::Duration,
@@ -76,12 +77,13 @@ pub struct RLBotCoreInterface {
 }
 
 impl RLBotCoreInterface {
-    pub fn load() -> io::Result<RLBotCoreInterface> {
+    pub fn load(rlbot_dll_directory: Option<&Path>) -> io::Result<RLBotCoreInterface> {
         if INITIALIZED.swap(true, Ordering::SeqCst) {
             panic!("RLBot can only be initialized once");
         }
 
-        let library = Library::new("RLBot_Core_Interface.dll")?;
+        let filename = maybe_join(rlbot_dll_directory, "RLBot_Core_Interface.dll");
+        let library = Library::new(filename)?;
 
         // This DLL does not seem to clean itself up all the way when unloaded, so to
         // avoid segfaults/etc we need to make sure it stays loaded until the process

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -59,17 +59,17 @@ pub fn run_bot<B: Bot>(mut bot: B) -> Result<(), Box<Error>> {
         .map_err(|_| Box::<Error>::from("could not parse framework arguments"))?
         .ok_or_else(|| Box::<Error>::from("not launched by framework"))?;
 
-    let rlbot = rlbot::init_with_options(
-        rlbot::InitOptions::new().rlbot_dll_directory(args.rlbot_dll_directory),
-    )?;
+    let player_index = args.player_index;
 
-    bot.set_player_index(args.player_index as usize);
+    let rlbot = rlbot::init_with_options(args.into())?;
+
+    bot.set_player_index(player_index as usize);
 
     let mut packets = rlbot.packeteer();
     loop {
         let packet = packets.next()?;
         let input = bot.tick(&packet);
-        rlbot.update_player_input(input, args.player_index)?;
+        rlbot.update_player_input(input, player_index)?;
     }
 }
 
@@ -135,6 +135,12 @@ pub struct FrameworkArgs {
     pub player_index: i32,
 
     _non_exhaustive: (),
+}
+
+impl From<FrameworkArgs> for rlbot::InitOptions {
+    fn from(args: FrameworkArgs) -> Self {
+        Self::new().rlbot_dll_directory(args.rlbot_dll_directory)
+    }
 }
 
 #[cfg(test)]

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -1,7 +1,7 @@
 //! This module contains code for interoperating with RLBot's BotManager.
 
 use crate::{ffi, rlbot};
-use std::{env, error::Error};
+use std::{env, error::Error, path::PathBuf};
 
 /// A bot that can run within the RLBot framework. Instances of `Bot` are used
 /// by the [`run_bot`] function.
@@ -55,27 +55,131 @@ pub trait Bot {
 ///
 /// [`examples/bot`]: https://github.com/whatisaphone/rlbot-rust/blob/master/examples/bot/main.rs
 pub fn run_bot<B: Bot>(mut bot: B) -> Result<(), Box<Error>> {
-    // Currently this only needs to interoperate with one caller – RLBot Python's
-    // BaseSubprocessAgent. No public interface has been committed to, so we can
-    // afford to be rigid and inflexible with the parsing.
-    let mut args = env::args().skip(1);
-    if args.next().as_ref().map(|s| &s[..]) != Some("--player-index") {
-        return Err(protocol_err());
-    }
-    let player_index: i32 = args.next().ok_or_else(protocol_err)?.parse()?;
+    let args = parse_framework_args()
+        .map_err(|_| Box::<Error>::from("could not parse framework arguments"))?
+        .ok_or_else(|| Box::<Error>::from("not launched by framework"))?;
 
-    let rlbot = rlbot::init()?;
+    let rlbot = rlbot::init_with_options(
+        rlbot::InitOptions::new().rlbot_dll_directory(args.rlbot_dll_directory),
+    )?;
 
-    bot.set_player_index(player_index as usize);
+    bot.set_player_index(args.player_index as usize);
 
     let mut packets = rlbot.packeteer();
     loop {
         let packet = packets.next()?;
         let input = bot.tick(&packet);
-        rlbot.update_player_input(input, player_index)?;
+        rlbot.update_player_input(input, args.player_index)?;
     }
 }
 
-fn protocol_err() -> Box<Error> {
-    From::from("Framework protocol violation")
+/// Parse the arguments passed by the RLBot framework.
+///
+/// This function returns:
+///
+/// * `Ok(Some(args))` – if the app was launched by the framework.
+/// * `Ok(None)` – if the app was *not* launched by the framework.
+/// * `Err(_)` – if it appears the app was launched by the framework, but we
+///   could not understand the arguments.
+pub fn parse_framework_args() -> Result<Option<FrameworkArgs>, ()> {
+    parse_framework_command_line(env::args().skip(1))
+}
+
+fn parse_framework_command_line(
+    mut args: impl Iterator<Item = String>,
+) -> Result<Option<FrameworkArgs>, ()> {
+    // Currently this only needs to interoperate with one caller – RLBot Python's
+    // BaseSubprocessAgent. No public interface has been committed to, so we can
+    // afford to be rigid and inflexible with the parsing.
+
+    if args.next().as_ref().map(|s| &s[..]) != Some("--rlbot-version") {
+        return Ok(None); // not launched by the framework
+    }
+    let rlbot_version = args.next().ok_or(())?;
+
+    if args.next().as_ref().map(|s| &s[..]) != Some("--rlbot-dll-directory") {
+        return Err(());
+    }
+    let rlbot_dll_directory = PathBuf::from(args.next().ok_or(())?);
+
+    if args.next().as_ref().map(|s| &s[..]) != Some("--player-index") {
+        return Err(());
+    }
+    let player_index = args.next().ok_or(())?.parse().map_err(|_| ())?;
+
+    Ok(Some(FrameworkArgs {
+        rlbot_version,
+        rlbot_dll_directory,
+        player_index,
+        _non_exhaustive: (),
+    }))
+}
+
+/// The arguments passed by the RLBot framework.
+pub struct FrameworkArgs {
+    /// The version of the RLBot framework used to launch the app. This is the
+    /// same as the version shown when you run this Python code:
+    ///
+    /// ```python
+    /// import rlbot
+    /// print(rlbot.__version__)
+    /// ```
+    pub rlbot_version: String,
+
+    /// The directory containing `RLBot_Core_Interface.dll` and
+    /// `RLBot_Injector.exe`.
+    pub rlbot_dll_directory: PathBuf,
+
+    /// The index of the player you're controlling in the
+    /// [`LiveDataPacket::GameCars`](ffi::LiveDataPacket::GameCars) array.
+    pub player_index: i32,
+
+    _non_exhaustive: (),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pfcl(ss: Vec<&str>) -> Result<Option<FrameworkArgs>, ()> {
+        parse_framework_command_line(ss.into_iter().map(|s| s.to_string()))
+    }
+
+    #[test]
+    fn parse_framework_args() {
+        let args = pfcl(vec![
+            "--rlbot-version",
+            "1.8.1",
+            "--rlbot-dll-directory",
+            "/tmp",
+            "--player-index",
+            "0",
+        ])
+        .unwrap()
+        .unwrap();
+        assert_eq!(args.rlbot_version, "1.8.1");
+        assert_eq!(args.rlbot_dll_directory.to_str().unwrap(), "/tmp");
+        assert_eq!(args.player_index, 0);
+    }
+
+    #[test]
+    fn parse_empty_command_line() {
+        let args = pfcl(vec![]).unwrap();
+        assert!(args.is_none());
+    }
+
+    #[test]
+    fn parse_non_matching_command_line() {
+        let args = pfcl(vec!["--unrelated-argument"]).unwrap();
+        assert!(args.is_none());
+    }
+
+    #[test]
+    fn parse_error() {
+        let args = pfcl(vec!["--rlbot-version"]);
+        assert!(args.is_err());
+
+        let args = pfcl(vec!["--rlbot-version", "1.8.1"]);
+        assert!(args.is_err());
+    }
 }

--- a/src/inject.rs
+++ b/src/inject.rs
@@ -2,10 +2,12 @@
 //! injector. It is basically a reimplementation of
 //! https://github.com/RLBot/RLBot/blob/928d0b1660618ef2c88b8aaf218189e8fb6b744b/src/main/python/rlbot/utils/structures/game_interface.py#L175
 
-use std::{error::Error, fmt, mem, process::Command, thread::sleep, time::Duration};
+use crate::utils::maybe_join;
+use std::{error::Error, fmt, mem, path::Path, process::Command, thread::sleep, time::Duration};
 
-pub fn inject_dll() -> Result<InjectorCode, Box<Error>> {
-    let code = Command::new("RLBot_Injector")
+pub fn inject_dll(rlbot_dll_directory: Option<&Path>) -> Result<InjectorCode, Box<Error>> {
+    let program = maybe_join(rlbot_dll_directory, "RLBot_Injector");
+    let code = Command::new(program)
         .arg("hidden")
         .status()?
         .code()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ pub use crate::{
     packeteer::Packeteer,
     physicist::Physicist,
     render::{Color, RenderGroup},
-    rlbot::{init, RLBot},
+    rlbot::{init, init_with_options, InitOptions, RLBot},
     rlbot_generated::rlbot::flat,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@
 
 pub mod ffi;
 pub use crate::{
-    framework::{run_bot, Bot},
+    framework::{parse_framework_args, run_bot, Bot, FrameworkArgs},
     packeteer::Packeteer,
     physicist::Physicist,
     render::{Color, RenderGroup},
@@ -140,3 +140,4 @@ pub mod state;
 mod state_convert;
 #[cfg(feature = "use-nalgebra")]
 mod state_nalgebra;
+mod utils;

--- a/src/rlbot.rs
+++ b/src/rlbot.rs
@@ -14,6 +14,14 @@ use std::{
 
 /// Initializes RLBot and returns a ready-to-use [`RLBot`] object.
 ///
+/// This function works exactly as [`init_with_options`]. Take a look there for
+/// more details.
+pub fn init() -> Result<RLBot, Box<Error>> {
+    init_with_options(Default::default())
+}
+
+/// Initializes RLBot and returns a ready-to-use [`RLBot`] object.
+///
 /// This function will inject the RLBot core DLL into Rocket League, and then
 /// load the interface DLL. It might sleep for some time while it waits for
 /// RLBot to fully initialize.
@@ -50,10 +58,6 @@ use std::{
 /// See [`examples/simple`] for a complete example.
 ///
 /// [`examples/simple`]: https://github.com/whatisaphone/rlbot-rust/blob/master/examples/simple.rs
-pub fn init() -> Result<RLBot, Box<Error>> {
-    init_with_options(Default::default())
-}
-
 pub fn init_with_options(options: InitOptions) -> Result<RLBot, Box<Error>> {
     let rlbot_dll_directory = options.rlbot_dll_directory.as_ref().map(|p| p.as_path());
 
@@ -65,16 +69,25 @@ pub fn init_with_options(options: InitOptions) -> Result<RLBot, Box<Error>> {
     Ok(RLBot::new(interface))
 }
 
+/// Options for customizing the way the framework is initialized.
 #[derive(Default)]
 pub struct InitOptions {
     rlbot_dll_directory: Option<PathBuf>,
 }
 
 impl InitOptions {
+    /// Constructs a new `InitOptions`.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets the directory in which to search for the RLBot DLLs.
+    ///
+    /// This should be set to the directory containing [these
+    /// files][rlbot-dlls]. If this not set, the system's standard DLL search
+    /// order will be used.
+    ///
+    /// [rlbot-dlls]: https://github.com/RLBot/RLBot/tree/cf5ca2794e153eef583eec093c2d9ea6e7afccd9/src/main/python/rlbot/dll
     pub fn rlbot_dll_directory(mut self, rlbot_dll_directory: impl Into<PathBuf>) -> Self {
         self.rlbot_dll_directory = Some(rlbot_dll_directory.into());
         self

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,8 @@
+use std::path::{Path, PathBuf};
+
+pub fn maybe_join(base: Option<&Path>, path: impl AsRef<Path>) -> PathBuf {
+    match base {
+        Some(base) => base.join(path),
+        None => path.as_ref().to_path_buf(),
+    }
+}


### PR DESCRIPTION
This loads DLLs from the directory given by the framework, instead of relying on `PATH`. It also exposes the parsed args to users of the library, if they want them.

This depends on https://github.com/RLBot/RLBot/pull/316